### PR TITLE
Update BaseSelf-Sufficiency.cfg

### DIFF
--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseSelf-Sufficiency.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseSelf-Sufficiency.cfg
@@ -75,7 +75,39 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport|USILifeSupport|Snacks]
 		type = Any
 		
 		title = Have at least one life support recycler, cultivator, or agroponics unit
+		PARAMETER
+		{	// latest and greatest USI format a greenhouse module
+			name = swap-converter
+			type = PartValidation
 		
+			FILTER
+			{
+				MODULE
+				{
+					name = USI_ConverterSwapOption
+					
+					// don't restrict inputs to allow different types of greenhouse modules
+					OUTPUT_RESOURCE
+					{
+						ResourceName = Supplies
+					}
+				}
+			}
+		}		
+		PARAMETER
+		{	// latest and greatest USI format for a recycler
+			name = swap-recycler
+			type = PartValidation
+		
+			FILTER
+			{
+				MODULE
+				{
+					name = USILS_LifeSupportRecyclerSwapOption
+				}
+			}
+		}		
+
 		PARAMETER
 		{
 			name = usi-converter


### PR DESCRIPTION
Latest versions of USI Life support changed module names for recyclers and supplies resource converters. This update adds the new format to the contract parameters without deleting old formats.