### PR TITLE
Add partial SSPXR compatibility

### DIFF
--- a/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
@@ -167,17 +167,36 @@ CONTRACT_TYPE
         }
 		//OPTIONAL Checks for cupola
 		PARAMETER
-        {
-            name = PartValidation
-            type = PartValidation
-            title = Include a cupola (optional)
+		{
+			name = PartValidation
+			type = Any
+			title = Include a cupola or an observatory (optional)
 			optional = true
-			hideChildren = true
-            
-            part = cupola
-            minCount = 1
-            
-        }
+			rewardFunds = 20000.0
+			
+				PARAMETER
+				{
+					name = PartValidation
+					type = PartValidation
+					
+					part = cupola
+					minCount = 1
+					
+				}
+				PARAMETER:NEEDS[StationPartsExpansionRedux]
+				{
+					name = PartValidation
+					type = PartValidation
+					
+					part = sspx-cupola-125-1
+					part = sspx-cupola-1875-1
+					part = sspx-observation-25-1
+					part = sspx-cupola-375-1
+					part = sspx-dome-cupola-5-1
+					minCount = 1
+					
+				}
+		}
 		
 		//Checks for Supplies (USI Life Support)
 		PARAMETER:NEEDS[USILifeSupport]
@@ -204,7 +223,6 @@ CONTRACT_TYPE
 				type = PartValidation
 				title = Include a Mobile Processing Lab MPL-LG-2
 				rewardFunds = 75000.0
-				hideChildren = true
 				
 				partModule = ModuleScienceLab
 			}
@@ -214,8 +232,7 @@ CONTRACT_TYPE
 				name = PartValidation
 				type = PartValidation
 				title = Include a TH-NKR Research Lab
-				rewardFunds = 85000.0
-				hideChildren = true
+				rewardFunds = 112000.0
 				
 				part = StnSciLab
 			}
@@ -226,9 +243,48 @@ CONTRACT_TYPE
 				type = PartValidation
 				title = Include a Science Laboratory
 				rewardFunds = 75000.0
-				hideChildren = true
 
 				partModule = Laboratory
+			}
+
+			PARAMETER:NEEDS[StationPartsExpansionRedux]
+			{
+				name = PartValidation
+				type = PartValidation
+				title = Include a PMA-4 'Nature' Science Lab
+				rewardFunds = 58000.0
+				
+				part = sspx-science-1875-1
+			}
+
+			PARAMETER:NEEDS[StationPartsExpansionRedux]
+			{
+				name = PartValidation
+				type = PartValidation
+				title = Include a PXL-2 'Fate' Deep-Space Laboratory Module
+				rewardFunds = 86800.0
+				
+				part = sspx-lab-375-1
+			}
+
+			PARAMETER:NEEDS[StationPartsExpansionRedux]
+			{
+				name = PartValidation
+				type = PartValidation
+				title = Include an SDV-6 'Delphi' Science Module 
+				rewardFunds = 109600.0
+				
+				part = sspx-lab-5-1
+			}
+
+			PARAMETER:NEEDS[StationPartsExpansionRedux]
+			{
+				name = PartValidation
+				type = PartValidation
+				title = Include an SDV-X 'Cronus' Extensible Centrifuge
+				rewardFunds = 181000.0
+				
+				part = sspx-expandable-centrifuge-5-1
 			}
 		}
 		

--- a/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
@@ -75,16 +75,16 @@ CONTRACT_TYPE
         }
 
         //Check for a Docking Port
-		PARAMETER
-		{
-			name = PartValidation
-			type = PartValidation
-			
-			partModule = ModuleDockingNode
-			minCount = 1
-		}
-		
-		//Check for crew capacity
+	PARAMETER
+	{
+		name = PartValidation
+		type = PartValidation
+
+		partModule = ModuleDockingNode
+		minCount = 1
+	}
+
+	//Check for crew capacity
         PARAMETER
         {
             name = HabModuleChild
@@ -158,42 +158,41 @@ CONTRACT_TYPE
 			PARAMETER:NEEDS[Kopernicus]
 			{
 				name = PartValidationRTG
-                type = PartValidation
-                hideChildren = true
-                title = 1 or more solar panels
-                partModule = KopernicusSolarPanel
-                minCount = 1
+				type = PartValidation
+				hideChildren = true
+				title = 1 or more solar panels
+				partModule = KopernicusSolarPanel
+				minCount = 1
 			}
-        }
-		//OPTIONAL Checks for cupola
-		PARAMETER
+        	}
+		//OPTIONAL Checks for cupola without SSPXR or cupola and observatories with SSPXR
+		PARAMETER:NEEDS[!StationPartsExpansionRedux]
 		{
 			name = PartValidation
-			type = Any
-			title = Include a cupola or an observatory (optional)
+			type = PartValidation
+			title = Include a cupola (optional)
 			optional = true
 			rewardFunds = 20000.0
-			
-				PARAMETER
-				{
-					name = PartValidation
-					type = PartValidation
-					
-					part = cupola
-					
-				}
-				PARAMETER:NEEDS[StationPartsExpansionRedux]
-				{
-					name = PartValidation
-					type = PartValidation
-					
-					part = sspx-cupola-125-1
-					part = sspx-cupola-1875-1
-					part = sspx-observation-25-1
-					part = sspx-cupola-375-1
-					part = sspx-dome-cupola-5-1
-					
-				}
+
+			part = cupola
+
+		}
+
+		PARAMETER:NEEDS[StationPartsExpansionRedux]
+		{
+			name = PartValidation
+			type = PartValidation
+			title = Include a cupola or an observation module (optional)
+			optional = true
+			rewardFunds = 20000.0
+
+			part = cupola
+			part = sspx-cupola-125-1
+			part = sspx-cupola-1875-1
+			part = sspx-observation-25-1
+			part = sspx-cupola-375-1
+			part = sspx-dome-cupola-5-1
+
 		}
 		
 		//Checks for Supplies (USI Life Support)

--- a/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCore.cfg
@@ -180,7 +180,6 @@ CONTRACT_TYPE
 					type = PartValidation
 					
 					part = cupola
-					minCount = 1
 					
 				}
 				PARAMETER:NEEDS[StationPartsExpansionRedux]
@@ -193,7 +192,6 @@ CONTRACT_TYPE
 					part = sspx-observation-25-1
 					part = sspx-cupola-375-1
 					part = sspx-dome-cupola-5-1
-					minCount = 1
 					
 				}
 		}


### PR DESCRIPTION
Added cupolas, observatories and science labs from Stockalike Station Parts Expanded Re-something v2.0.3 to station core contracts. Also semi-balanced rewards for related parts.

To do: add separate contracts from SSPXR science labs (it's not that easy as they all need balanced rewards and descriptions).
Maybe to do: different rewards for different cupolas, but it's better to have something than nothing.

Previously, including a cupola was optional but didn't reward the player (why).