### PR TITLE
Fix SSPXr compatibility

### DIFF
--- a/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCoreCombined.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCoreCombined.cfg
@@ -170,14 +170,13 @@ CONTRACT_TYPE
 		{
 			name = PartValidationSSPX
 			type = All
-			optional = false
 			title = Include a station core and a habitat
 
 			PARAMETER
 			{
 				name = PartValidationStationCore
 				type = PartValidation
-				title = Include a station core
+				title = Include a station core from Station Parts Expansion
 				hideChildren = true
 			
 				part = sspx-core-125-1
@@ -191,18 +190,25 @@ CONTRACT_TYPE
 			PARAMETER
 			{
 				name = PartValidHab
-				type = PartValidation
-				title = Include a habitat module
-				hideChildren = true
-				minCount = 1
+				type = Any
+				title = Include one of the following habitat modules
 
 				PARAMETER
 				{
 					name = PartValidationHab
 					type = PartValidation
-					title = Include a habitat module
+					title = A PPD-10 Hitchhiker Storage Container
 					hideChildren = true
-					optional = true			
+
+					part = crewCabin
+					minCount = 1
+				}
+				PARAMETER
+				{
+					name = PartValidationHab
+					type = PartValidation
+					title = A habitat module from Station Parts Expansion
+					hideChildren = true
 
 					part = sspx-habitation-125-1		
 					part = sspx-inflatable-centrifuge-125-1
@@ -213,7 +219,6 @@ CONTRACT_TYPE
 					part = sspx-habitation-1875-1
 					part = sspx-habitation-1875-2
 					part = sspx-habitation-25-1
-					part = crewCabin
 					part = sspx-inflatable-centrifuge-25-1
 					part = sspx-inflatable-hab-25-1
 					part = sspx-inflatable-hab-25-2
@@ -225,16 +230,15 @@ CONTRACT_TYPE
 					part = sspx-habitation-5-1
 					part = sspx-habitation-5-2
 					part = sspx-expandable-centrifuge-5-1
+					minCount = 1
 				}
 				PARAMETER:NEEDS[TokamakIndustries]
 				{
 					name = PartValidationHabTokamak
 					type = PartValidation
-					title = Include a habitat module (Tokamak)
+					title = A habitat module from Tokamak Industries
 					hideChildren = true
-					optional = true			
 
-					// From Tokomak
 					part = iberico_hab101R
 					part = iberico_hab202
 					part = iberico_hab202R
@@ -246,7 +250,6 @@ CONTRACT_TYPE
 					part = TIinflato2
 					part = TIinflatoFlat
 					part = TIorbitalorb
-
 					minCount = 1						
 				}
 			}


### PR DESCRIPTION
`StationCoreCombined.cfg` checks if SSPXr is installed; if so, it adds a requirement "Include a station core and a habitat" to the comtract. However, the code isn't quite right. An error will occur if SSPXr is installed, making the most basic contract unable to be loaded:

```
[LOG 23:17:50.958] [INFO] ContractConfigurator.ContractType: Loading CONTRACT_TYPE: 'StationCoreCombined'
[ERR 23:17:50.979] ContractConfigurator.PartValidationFactory: CONTRACT_TYPE 'StationCoreCombined', PARAMETER 'PartValidHab' of type 'PartValidation': unexpected node 'PARAMETER'.

[WRN 23:17:50.987] ContractConfigurator.ContractType: Errors encountered while trying to load CONTRACT_TYPE 'StationCoreCombined'
[LOG 23:17:50.990] [INFO] ContractConfigurator.ContractConfigurator: Loaded 19 out of 20 CONTRACT_TYPE nodes.
```

This PR fixes this issue. The logic is:

- Check if SSPXr is installed
  - NO: "Include a station core and a habitat" is not a requirement
  - YES: "Include a station core and a habitat" is a requirement
    - An SSPXr station core is required
    - A habitat module is required, which could be any of the following:
      - PPD-10 Hitchhiker Storage Container (stock)
      - A habitat module from SSPXr
      - A habitat module from Tokamak (only if Tokamak is installed, of course)

I've tested the fix and it works for all occasions (SSPXr is installed or not / Tokamak is installed or not).