### PR TITLE
Power module validation consistency, KopernicusSolarPanel compalibility and typo fixes

### DIFF
--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE
 	genericTitle = Build an Offworld Base
 	genericDescription = Our engineers were thinking on a way to have kerbals on other worlds and let them stay there long term.
     synopsis = We want you to start the creation of @/targetBody1 Base.   
-    completedMessage = You have Create the initial stage of @/targetBody1 Base.
+    completedMessage = You have created the initial stage of @/targetBody1 Base.
     minExpiry = 1.0
     maxExpiry = 7.0
     cancellable = true

--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
@@ -94,16 +94,25 @@ type = All
 			PARAMETER
 			{
                 name = Solar
-				title = Solar
+				title = 1 or more solar panels
 				type = PartValidation
 				hideChildren = true
 				partModule = ModuleDeployableSolarPanel
 				minCount = 1 	     
 			}
+			PARAMETER:NEEDS[Kopernicus]
+			{
+                name = Solar
+				title = 1 or more solar panels
+				type = PartValidation
+				hideChildren = true
+				partModule = KopernicusSolarPanel
+				minCount = 1 	     
+			}
 			PARAMETER
 			{
                 name = Generator
-				title = RTG
+				title = 1 or more RTGs
 				type = PartValidation
 				hideChildren = true
 				partModule = ModuleGenerator
@@ -112,7 +121,7 @@ type = All
 			PARAMETER
 			{
                 name = Generator1
-				title = Fuel Cell
+				title = 1 or more Fuel Cells
 				type = PartValidation
 				hideChildren = true
 				part = FuelCell
@@ -121,7 +130,7 @@ type = All
 			PARAMETER
 			{
                 name = Generator2
-				title = Fuel Cell Array
+				title = 1 or more Fuel Cell Arrays
 				type = PartValidation
 				hideChildren = true
 				part = FuelCellArray

--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCreate.cfg
@@ -89,8 +89,8 @@ type = All
         {
             name = Any
 			type = Any
-			hideChildren = true		
-			title = Can Generate Power (supports all stock methods and Near Future Solar/Electrical)
+			hideChildren = false
+			title = Have one of the following power generators
 			PARAMETER
 			{
                 name = Solar

--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCrewRotation.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseCrewRotation.cfg
@@ -9,7 +9,7 @@ CONTRACT_TYPE
     synopsis = Bring @/targetKerbal1 and @/targetKerbal2 back to @/targetBody2.
     completedMessage = Kerbonaut @/targetKerbal1 would like to thank you. They got back just in time.
     minExpiry = 1
-    maxExpiry = 7)
+    maxExpiry = 7
     cancellable = true
     declinable = true
 	maxSimultaneous = 1

--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseScience.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseScience.cfg
@@ -4,8 +4,8 @@ CONTRACT_TYPE
     title = Science Expansion for @/ScienceTarget
 	genericTitle = Add a Science Lab to a Base
     group = BasesandStations
-	description = Our scientists thinks that maybe @/targetBody1 have some scientific value so this is were you come in.
-	genericDescription = Our scientists thinks that maybe our base can provide some scientific value,
+	description = Our scientists think that maybe @/targetBody1 have some scientific value so this is where you come in.
+	genericDescription = Our scientists think that maybe our base can provide some scientific value so this is where you come in.
     synopsis = Add a new Science Lab to @/ScienceTarget.
     completedMessage = Finally our scientist are investigating something.
     minExpiry = 1

--- a/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseSelf-Sufficiency.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/BaseMissions/BaseSelf-Sufficiency.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport|USILifeSupport|Snacks]
     title = Life Support Expansion for @/LSTarget
 	genericTitle = Base Life Support Expansion
     group = BasesandStations
-	description = Some kerbals down there on @/LSTarget are complaining about their dependence on the ressuply vessels so this is were you come in.
+	description = Some kerbals down there on @/LSTarget are complaining about their dependence on the ressuply vessels so this is where you come in.
 	genericDescription = We don't want to be relying on resupply ships. Make the base self-sufficient.
     synopsis = Add a new Self-sufficiency module to @/LSTarget.
     completedMessage = Finally our Kerbals aren't complaining.

--- a/GameData/ContractPacks/KerbinSpaceStation/CompatibilityPacks/StationScience/ModuleStationScienceCyclotron.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/CompatibilityPacks/StationScience/ModuleStationScienceCyclotron.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE:NEEDS[StationScience]
     title = Add a D-ZZY Cyclotron to @/targetVessel1
 	genericTitle = Add a D-ZZY Cyclotron to a Station
     group = BasesandStations
-	description = Wernher von Kerman accidentally discovered Kuarqs hiding in his clothes drier. Now he wants you to add a giant spinning thingymajig to @/targetVessel1 see if we can make more of them!
+	description = Wernher von Kerman accidentally discovered Kuarqs hiding in his clothes drier. Now he wants you to add a giant spinning thingymajig to @/targetVessel1 to see if we can make more of them!
 	genericDescription = Wernher von Kerman accidentally discovered Kuarqs hiding in his clothes drier. Now he wants you to launch a giant spinning thingymajig to the station to see if we can make more of them!
     synopsis = Add a D-ZZY Cyclotron to @/targetVessel1
     completedMessage = Well done!

--- a/GameData/ContractPacks/KerbinSpaceStation/CompatibilityPacks/StationScience/ModuleStationScienceSpectrometron.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/CompatibilityPacks/StationScience/ModuleStationScienceSpectrometron.cfg
@@ -4,8 +4,8 @@ CONTRACT_TYPE:NEEDS[StationScience]
     title = Add a WT-SIT Spectrometron to @/targetVessel1
 	genericTitle = Add a WT-SIT Spectrometron to a Station
     group = BasesandStations
-	description = We're sick of losing science precious science over transmission. Add a Spectrometron to @/targetVessel1 to reduce our science transmission losses.
-	genericDescription = We're sick of losing science precious science over transmission. Add a Spectrometron to the station to reduce our science transmission losses.
+	description = We're sick of losing precious science over transmission. Add a Spectrometron to @/targetVessel1 to reduce our science transmission losses.
+	genericDescription = We're sick of losing precious science over transmission. Add a Spectrometron to the station to reduce our science transmission losses.
     synopsis = Add a WT-SIT Spectrometron to @/targetVessel1
     completedMessage = Well done!
     
@@ -25,7 +25,7 @@ CONTRACT_TYPE:NEEDS[StationScience]
 	
 	targetBody = @/targetBody1
 	
-	//Find a Station with a Research Lab but less than 2 Cyclotrons
+	//Find a Station with a Research Lab but without a Spectrometron
 	DATA
     {
         type = Vessel

--- a/GameData/ContractPacks/KerbinSpaceStation/MaintenanceMissions/ReplaceFaultyModule.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/MaintenanceMissions/ReplaceFaultyModule.cfg
@@ -48,44 +48,37 @@ CONTRACT_TYPE
 		{
 			name = RTGSolar
 			type = Any
+			title = Have one of the following power generators
 			
 			PARAMETER
 			{
 				name = PartValidationSolar
 				type = PartValidation
-
 				// PartModule(s) to check for.  Optional, and can be specified multiple times.
 				partModule = ModuleDeployableSolarPanel
-
 				// Minimum count, default = 1
 				minCount = 1
-				title = Have a Solar Panel on board
+				title = 1 or more solar panels
 			}
 			
 			PARAMETER
 			{
 				name = PartValidationRTG
 				type = PartValidation
-
-				// PartModule(s) to check for.  Optional, and can be specified multiple times. Looking for an RTG
 				partModule = ModuleGenerator
-
-				// Minimum count, default = 1
 				minCount = 1
-				title = Have an RTG on board
+				title = 1 or more generators
 			}
 			
 			PARAMETER:NEEDS[NearFutureSolar]
 			{
-				name = PartValidationNFE
+				name = PartValidationNearFutureSolar
 				type = PartValidation
-
-				// PartModule(s) to check for.  Optional, and can be specified multiple times.
 				partModule = ModuleCurvedSolarPanel
-				// Minimum count, default = 1
 				minCount = 1
-				title = Have a Solar Panel on board
+				title = 1 or more curved solar panels
 			}
+
 			PARAMETER:NEEDS[NearFutureElectrical]
 			{
 				name = PartValidationNearFutureReactors
@@ -103,6 +96,16 @@ CONTRACT_TYPE
 				title = 1 or more radioisotope generators
 				hideChildren = true
 				partModule = ModuleRadioisotopeGenerator
+				minCount = 1
+			}
+
+			PARAMETER:NEEDS[Kopernicus]
+			{
+				name = PartValidationSolar
+				type = PartValidation
+				title = 1 or more solar panels
+				hideChildren = true
+				partModule = KopernicusSolarPanel
 				minCount = 1
 			}
 		}

--- a/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCoreCombined.cfg
+++ b/GameData/ContractPacks/KerbinSpaceStation/StationMissions/StationCoreCombined.cfg
@@ -104,7 +104,7 @@ CONTRACT_TYPE
 
 			PARAMETER
 			{
-				name = PartValidationRTG
+				name = PartValidationSolar
 				type = PartValidation
 				title = 1 or more solar panels
 				hideChildren = true
@@ -115,7 +115,7 @@ CONTRACT_TYPE
 				
 			PARAMETER
 			{
-				name = PartValidationSolar
+				name = PartValidationRTG
 				type = PartValidation
 				title = 1 or more generators
 				hideChildren = true
@@ -157,7 +157,7 @@ CONTRACT_TYPE
 			
 			PARAMETER:NEEDS[Kopernicus]
 			{
-				name = PartValidationRTG
+				name = PartValidationSolar
 				type = PartValidation
 				hideChildren = true
 				title = 1 or more solar panels


### PR DESCRIPTION
- `StationCoreCombined.cfg`, `ReplaceFaultyModule.cfg` and `BaseCreate.cfg` all have power module validation. But the titles are slightly different among contracts, and even in the same contracts. This PR makes them consistent.
- In `BaseCreate.cfg`, `hideChildren` is changed to `false` to show power module requirement explicitly, making it consistent with the other two contracts.
- Adds `KopernicusSolarPanel` validation to `ReplaceFaultyModule.cfg` and `BaseCreate.cfg`, so the two contracts are available when Kopernicus is installed.
- Fixes some typos.